### PR TITLE
fix: support ubuntu 22.04 and later

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # Build on slightly old machine for better GLIBC compatibility.
     env:
       TARGET: "x86_64-unknown-linux-gnu"
     steps:


### PR DESCRIPTION
Change GitHub Action runner image to Ubuntu 22.04 for Linux. This mitigates the glibc compatibility issues.

fix #10 