### PR TITLE
Fix Windows tray auto reconnect by passing config to oneshot

### DIFF
--- a/packages/xdwlan-login/src/lib/login.ts
+++ b/packages/xdwlan-login/src/lib/login.ts
@@ -29,7 +29,7 @@ export async function login(config: Config) {
     }
 
     logger.trace(
-      `LoginTask: filled up login form, username: ${config.username} password: ${config.password} domain: ${config.domain}`,
+      `LoginTask: filled up login form, username: ${config.username} password: <redacted> domain: ${config.domain}`,
     );
     await sleep(5000); // Wait 5 seconds before check login status.
   } else {

--- a/packages/xdwlan-login/src/windows/main.ts
+++ b/packages/xdwlan-login/src/windows/main.ts
@@ -1,6 +1,7 @@
 import { logger } from "@lib/logger";
 import { exit, handleSignal } from "@lib/instrumentation";
 import { oneshot } from "@lib/mode";
+import { getConfig } from "@lib/config";
 
 function main() {
   if (!process.env.XDWLAN_LOGIN_SERVER_PORT) {
@@ -8,10 +9,11 @@ function main() {
   }
 
   handleSignal();
+  const config = getConfig();
 
   let routineHandler: NodeJS.Timeout;
   async function routine() {
-    await oneshot();
+    await oneshot(config);
     routineHandler = setTimeout(routine, 60_000);
   }
   routine();
@@ -31,7 +33,7 @@ function main() {
       },
       "/login": {
         POST: async (request) => {
-          const status = await oneshot();
+          const status = await oneshot(config);
           return new Response(status ? "ok" : "no");
         },
       },


### PR DESCRIPTION
## Summary

This fixes Windows tray/server auto reconnect after offline detection.

The Windows server entrypoint was calling `oneshot()` without a config object. This stayed hidden while the network was already online because `oneshot()` returned before reaching `login(config)`. Once offline, the reconnect loop called `login(config)`, which accessed `config.url` and failed because `config` was undefined.

The patch loads config once in `src/windows/main.ts` and passes it to both the scheduled routine and the manual `/login` route.

It also redacts the password from trace logging in `src/lib/login.ts`.

## Verification

- `bunx tsc --noEmit`
- `bun run -F xdwlan-login build:windows`
- `cargo build --release`
- Windows server smoke test: `/health` returns `ok`, `/quit` returns `ok`

Fixes #22.
